### PR TITLE
chore: enable bitswap peer LRU cache

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -27,7 +27,7 @@ env:
   concurrency: 128
   pipelining: 16
   logLevel: info
-  cacheBlocksInfo: false
+  cacheBlocksInfo: true
   dynamodbBlocksTable: blocks
   dynamodbCarsTable: cars
 workerType: workerNode


### PR DESCRIPTION
Set to false for some reason 🤷‍♂️