### PR TITLE
Decrease max replicas

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -3,7 +3,7 @@ image:
 resources:
   limits:
     cpu: 2
-    memory: 3Gi
+    memory: 3.5Gi
   requests:
     cpu: 2
     memory: 3Gi

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,8 +2,8 @@ image:
   version: "20220707.1226"
 resources:
   limits:
-    cpu: 4
-    memory: 4Gi
+    cpu: 2
+    memory: 3Gi
   requests:
     cpu: 2
     memory: 3Gi

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -10,5 +10,6 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 4
-  maxReplicas: 300
-  targetCPUUtilizationPercentage: 50
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -10,6 +10,6 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 4
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 90


### PR DESCRIPTION
- Memory leak is making Bitswap Peer to scale more than it should