### PR TITLE
Release 0.10.1 to staging + ImagePull Always policy

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         workerType: {{ .Values.workerType }}
     spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
+      imagePullPolicy: Always
       containers:
       - image: ghcr.io/elastic-ipfs/bitswap-peer/app:{{ .Values.image.version }}
         name: {{ .Release.Name }}        

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
         workerType: {{ .Values.workerType }}
     spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
-      imagePullPolicy: Always
       containers:
       - image: ghcr.io/elastic-ipfs/bitswap-peer/app:{{ .Values.image.version }}
+        imagePullPolicy: Always
         name: {{ .Release.Name }}        
         env: 
         - name: PORT

--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -1,6 +1,6 @@
 namespace: staging-ep-bitswap-peer
 image:
-  version: '0.10.0'
+  version: '0.10.1'
 annotations:
   prometheus.io/path: metrics
   prometheus.io/port: '3001'

--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -1,6 +1,6 @@
 namespace: staging-ep-bitswap-peer
 image:
-  version: '0.5.3'
+  version: '0.10.0'
 annotations:
   prometheus.io/path: metrics
   prometheus.io/port: '3001'


### PR DESCRIPTION
- If we want to keep using the app version tag, rather than build date, we need to specify imagePull Always policy (Due to tag mutability).