### PR TITLE
1s readiness - backpressure

### DIFF
--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -15,10 +15,10 @@ service:
         successThreshold: 1
       readiness:
         initialDelaySeconds: 15
-        periodSeconds: 12
-        timeoutSeconds: 10
-        failureThreshold: 10
-        successThreshold: 1
+        periodSeconds: 1
+        timeoutSeconds: 1
+        failureThreshold: 1
+        successThreshold: 3
   additionalResourceTags:
     Environment: dev
 annotations:


### PR DESCRIPTION
failureThreshold: 1 => Will make the pod not ready in the first signal from the pod.
successThreshold: 3 => Pod need to respond 3 times (3 seconds) that is ready to receive new requests