### PR TITLE
refactor: reduce maximum connections each pod can service

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
         - name: LOG_REQUESTS
           value: {{ .Values.env.logRequests | squote }}
         {{ end -}}
+        - name: P2P_CONNECTION_MAX_CONNECTIONS
+          value: {{ .Values.env.p2pConnectionMaxConnections | squote }}
         resources:
           limits:
             cpu: {{ .Values.resources.limits.cpu }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -58,5 +58,6 @@ env:
   dynamodbCarsTableV1: prod-ep-v1-cars
   dynamodbLinkTableV1: prod-ep-v1-blocks-cars-position
   dynamodbConfigTable: prod-ep-bitswap-config
+  p2pConnectionMaxConnections: 1000
 workerType: workerNode
 serviceAccountName: bitswap-irsa


### PR DESCRIPTION
With 10,000 connections and a block batch limit of 512 we _could_, in the worst case scenario be asked for `10,000 * 512 * 1MB` of blocks concurrently which would require ~`5TB` of memory! More normally (perhaps - guestimated), each peer might have 3MB of data outstanding, which would still require `30GB` of memory.

This PR reduces the maximum number of connections to 1,000 so that in the above normal case we use `3GB` of the `6GB` of available memory, with room for bursts.