### PR TITLE
chore: update staging bitswap peer to v0.17.2

### DIFF
--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -1,6 +1,6 @@
 namespace: staging-ep-bitswap-peer
 image:
-  version: '0.17.1'
+  version: '0.17.2'
 annotations:
   prometheus.io/path: metrics
   prometheus.io/port: '3001'

--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -1,6 +1,6 @@
 namespace: staging-ep-bitswap-peer
 image:
-  version: '0.17.0'
+  version: '0.17.1'
 annotations:
   prometheus.io/path: metrics
   prometheus.io/port: '3001'


### PR DESCRIPTION
Similarly as https://github.com/elastic-ipfs/bitswap-peer-deployment/pull/71 updating version to include https://github.com/elastic-ipfs/bitswap-peer/pull/194 + temporarily remove yamux