### PR TITLE
chore: update prod bitswap peer to v0.17.2

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -1,5 +1,5 @@
 image:
-  version: '0.17.1'
+  version: '0.17.2'
 resources:
   limits:
     cpu: 4

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -1,5 +1,5 @@
 image:
-  version: '0.17.0'
+  version: '0.17.1'
 resources:
   limits:
     cpu: 4


### PR DESCRIPTION
Similarly as https://github.com/elastic-ipfs/bitswap-peer-deployment/pull/72 updating version to include https://github.com/elastic-ipfs/bitswap-peer/pull/194 + temporarily remove yamux