### PR TITLE
chore: update staging bitswap peer to v0.18.0

### DIFF
--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -1,6 +1,6 @@
 namespace: staging-ep-bitswap-peer
 image:
-  version: '0.17.2'
+  version: '0.18.0'
 annotations:
   prometheus.io/path: metrics
   prometheus.io/port: '3001'


### PR DESCRIPTION
Adds https://github.com/elastic-ipfs/bitswap-peer/pull/197 to staging