### PR TITLE
chore: update prod bitswap peer to v0.18.0

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -1,5 +1,5 @@
 image:
-  version: '0.17.2'
+  version: '0.18.0'
 resources:
   limits:
     cpu: 4


### PR DESCRIPTION
Adds https://github.com/elastic-ipfs/bitswap-peer/pull/197 to prod