### PR TITLE
refactor: increase liveness probe timeout

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,7 +16,8 @@ service:
       enable: "true"
       liveness: 
         initialDelaySeconds: 15
-        periodSeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 5
       readiness:
         initialDelaySeconds: 15
         periodSeconds: 12


### PR DESCRIPTION
Our pods are being restarted because the liveness probe times out:

```console
$ kubectl get event --namespace bitswap-peer --field-selector involvedObject.name=bitswap-peer-775fff6bd-8zsfn

LAST SEEN   TYPE      REASON      OBJECT                             MESSAGE
51m         Warning   Unhealthy   pod/bitswap-peer-775fff6bd-8zsfn   Liveness probe failed: Get "http://10.0.1.8:3001/liveness": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
70s         Warning   BackOff     pod/bitswap-peer-775fff6bd-8zsfn   Back-off restarting failed container
5m55s       Warning   Unhealthy   pod/bitswap-peer-775fff6bd-8zsfn   (combined from similar events): Liveness probe failed: Get "http://10.0.1.8:3001/liveness": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The default value is 1s. A busy peer could definitely exceed that, lets see if an increased timeout helps.