### PR TITLE
chore: update staging bitswap peer to 20230602.1121

### DIFF
--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -1,6 +1,6 @@
 namespace: staging-ep-bitswap-peer
 image:
-  version: '0.19.2'
+  version: '20230602.1121'
 annotations:
   prometheus.io/path: metrics
   prometheus.io/port: '3001'


### PR DESCRIPTION
Using: https://github.com/elastic-ipfs/bitswap-peer/pull/214

License: MIT