### PR TITLE
chore: update prod bitswap peer to 20230602.1121

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -1,5 +1,5 @@
 image:
-  version: '0.19.2'
+  version: '20230602.1121'
 resources:
   limits:
     cpu: 4


### PR DESCRIPTION
Using https://github.com/elastic-ipfs/bitswap-peer/pull/214

License: MIT