### PR TITLE
fix: adjust resource requirements to allow some auto-scaling

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,10 +2,10 @@ image:
   version: '20230602.1121'
 resources:
   limits:
-    cpu: 3
+    cpu: 2
     memory: 7Gi
   requests:
-    cpu: 2
+    cpu: 0.5
     memory: 4Gi
 service:
   additionalResourceTags:
@@ -18,8 +18,8 @@ autoscaling:
   enabled: true
   minReplicas: 20
   maxReplicas: 60
-  targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 90
+  targetCPUUtilizationPercentage: 50
+  targetMemoryUtilizationPercentage: 80
 rollout:
   strategy:
     canary:
@@ -28,7 +28,3 @@ rollout:
         - pause: {}
         - setWeight: 40
         - pause: {}
-        - setWeight: 60
-        - pause: { duration: 10 }
-        - setWeight: 80
-        - pause: { duration: 10 }

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,11 +2,11 @@ image:
   version: '20230602.1121'
 resources:
   limits:
-    cpu: 4
+    cpu: 3
     memory: 7Gi
   requests:
     cpu: 2
-    memory: 6Gi
+    memory: 4Gi
 service:
   additionalResourceTags:
     Environment: prod
@@ -16,8 +16,8 @@ annotations:
   prometheus.io/scrape: "true"
 autoscaling:
   enabled: true
-  minReplicas: 40
-  maxReplicas: 50
+  minReplicas: 20
+  maxReplicas: 60
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 90
 rollout:


### PR DESCRIPTION
currently we have 20 nodes trying to run 40 pods. 1 instance is failing.

no additional bitswap nodes are being started on the remaining 19 nodes as the resource rules require 6GiB per bitswap peer, and there is only 14GB usable per instance, so max 2 bs pods per instance.

This pr tweaks it so that we could scale between 1 to 3 bitswap peers per instances, assuming we stick with 20 instances.

notes: https://hackmd.io/@olizilla/deploy-eipfs

License: MIT