### PR TITLE
fix: scale between 2 or 3 pods across 14 instances

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -16,10 +16,10 @@ annotations:
   prometheus.io/scrape: "true"
 autoscaling:
   enabled: true
-  minReplicas: 20
-  maxReplicas: 60
-  targetCPUUtilizationPercentage: 50
-  targetMemoryUtilizationPercentage: 80
+  minReplicas: 28
+  maxReplicas: 42
+  targetCPUUtilizationPercentage: 60
+  targetMemoryUtilizationPercentage: 60
 rollout:
   strategy:
     canary:


### PR DESCRIPTION
Seeing pods restart more frequently so bumping up the scaling numbers as we now have 14 instances to play with. Pick numbers so we have either 2 or 3 pods per instances.

Dial down the mem usage scaling threshold so maybe it'll autoscale. We're not seeing much of that in practice currently.

License: MIT