### PR TITLE
chore: put 3 pods on most instances

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -16,8 +16,8 @@ annotations:
   prometheus.io/scrape: "true"
 autoscaling:
   enabled: true
-  minReplicas: 28
-  maxReplicas: 42
+  minReplicas: 36
+  maxReplicas: 51
   targetCPUUtilizationPercentage: 60
   targetMemoryUtilizationPercentage: 60
 rollout:


### PR DESCRIPTION
we have 18 instances. each can fit 3 pods. max pods is 54. I set max here to 51 so one instance (3 pods) can go down and the cluster can gracefully start 3 pods on the 3 instances that have 1 spot left while a new instance is provisioned.

License: MIT