### PR TITLE
chore: ensure we have at least 50 pods running

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -16,8 +16,8 @@ annotations:
   prometheus.io/scrape: "true"
 autoscaling:
   enabled: true
-  minReplicas: 36
-  maxReplicas: 51
+  minReplicas: 51
+  maxReplicas: 54
   targetCPUUtilizationPercentage: 60
   targetMemoryUtilizationPercentage: 60
 rollout:


### PR DESCRIPTION
our autoscaling rules are not yet calibrated. we need to explore scaling based on node event loop saturation as cpu usage is pretty steady regardless while mem usage is too spikey to be a useful indicator. the event loop utilization hitting 100% seems to corrolate more closely with when pods start struggling.

in the meantime lets ensure we have enough pods around and make full use of the instances we have

License: MIT