### PR TITLE
chore: allow 4 bs pods per instance

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -3,7 +3,7 @@ image:
 resources:
   limits:
     cpu: 1
-    memory: 5Gi
+    memory: 4Gi
   requests:
     cpu: 1
     memory: 3Gi

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,11 +2,11 @@ image:
   version: '20230602.1121'
 resources:
   limits:
-    cpu: 2
-    memory: 7Gi
+    cpu: 1
+    memory: 5Gi
   requests:
-    cpu: 0.5
-    memory: 4Gi
+    cpu: 1
+    memory: 3Gi
 service:
   additionalResourceTags:
     Environment: prod
@@ -16,10 +16,10 @@ annotations:
   prometheus.io/scrape: "true"
 autoscaling:
   enabled: true
-  minReplicas: 51
-  maxReplicas: 54
-  targetCPUUtilizationPercentage: 60
-  targetMemoryUtilizationPercentage: 60
+  minReplicas: 68
+  maxReplicas: 72
+  targetCPUUtilizationPercentage: 40
+  targetMemoryUtilizationPercentage: 40
 rollout:
   strategy:
     canary:


### PR DESCRIPTION
- we never see cpu usage go much over 0.5, and a standard node process wont use more than 1 so ensure each peer requests and is limited to 1 cpu
- we never see (last 30 days) mem go over 4.5Gi. it's spikey but the norm is < 2Gi.
- on our current instances we can fit 4 bitswap peers per if each one request 3Gi which is enough for 99% of the time and the burst provision covers the max usage.

last 30d mem usage.
<img width="1582" alt="Screenshot 2023-06-13 at 11 40 52" src="https://github.com/elastic-ipfs/bitswap-peer-deployment/assets/58871/a69f1d6f-f299-4824-b47d-fe663ce5af69">


License: MIT