### PR TITLE
feat: enable local lru block info (dynamo index) cache

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
           value: {{ .Values.env.cacheBlockData | squote }}
         - name: CACHE_BLOCK_INFO
           value: {{ .Values.env.cacheBlockInfo | squote }}
+        - name: CACHE_BLOCK_INFO_SIZE
+          value: {{ .Values.env.cacheBlockInfoSize | squote }}
         - name: PEER_ANNOUNCE_ADDR
           value: {{ .Values.env.peerAnnounceAddr | squote }}
         - name: AWS_CLIENT_CONCURRENCY

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -52,7 +52,8 @@ env:
   awsClientPipelining: 8
   logLevel: info
   cacheBlockData: false
-  cacheBlockInfo: false
+  cacheBlockInfo: true
+  cacheBlockInfoSize: 50000 # ~300b for an index item * 50k = ~15Mib (node get 3Gib)
   dynamodbBlocksTable: blocks
   dynamodbCarsTable: cars
   dynamodbBlocksTableV1: prod-ep-v1-blocks


### PR DESCRIPTION
- enable `cacheBlockInfo` which becomes `env.CACHE_BLOCK_INFO` for bitswap peer, enabling the LRU cache
- set `cacheBlockInfoSize` to set `env.CACHE_BLOCK_INFO_SIZE` to set the size of the LRU
- 50k items in cache a index each item is ~300b and 50k * 300b ~= 15Mib and each node gets 3Gib so seems legit.
  - and some nodes have 1k+ pending items so the cache should be an order of magnitude larger than the novel request rate to have any impact, else the LRU will just drop everything all the time.

note: this PR is also raised to so we trigger a restart of all of the bitswap pods to nudge more libp2p connections over to hoverboard.

see: https://github.com/elastic-ipfs/bitswap-peer/blob/41019945c00f739ca248223373b63395ceb0b04a/src/storage.js#L15

License: MIT