### PR TITLE
feat: reduce pods

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -17,7 +17,7 @@ annotations:
 autoscaling:
   enabled: true
   minReplicas: 1
-  maxReplicas: 4
+  maxReplicas: 72
   targetCPUUtilizationPercentage: 40
   targetMemoryUtilizationPercentage: 40
 rollout:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -16,8 +16,8 @@ annotations:
   prometheus.io/scrape: "true"
 autoscaling:
   enabled: true
-  minReplicas: 68
-  maxReplicas: 72
+  minReplicas: 1
+  maxReplicas: 4
   targetCPUUtilizationPercentage: 40
   targetMemoryUtilizationPercentage: 40
 rollout:


### PR DESCRIPTION
[hoverboard 🛹](https://github.com/web3-storage/hoverboard) has taken on the workload. Reduce the minimum number of pods. The plan is to let autoscalers wind down the number of pods and instances... FOR SCIENCE! ...to see if they ever really truely worked.

License: MIT